### PR TITLE
Only listen on `localhost` by default, control with `CRUSHEE_HOST` environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For the average user, It's recommended that you use the [desktop app](https://gi
 - Run *npm install*
 - If you're missing any image libraries (depending on your OS), get those and re-run *npm install* as needed
 - Run *node index.js*
-- Access Crushee through port 1603. By default, it listens for any host name. (ex. http://localhost:1603)
+- Access Crushee through port 1603. By default, it listens only on the loopback interface (ex. `http://localhost:1603`). You may change the listening interface by modifying the `CRUSHEE_HOST` environment variable (ex. to listen to all network interfaces, `export CRUSHEE_HOST=0.0.0.0`) and the listening port by modifying either the `CRUSHEE_PORT` or `PORT` environment variable (ex. to listen on 8080/tcp, `export CRUSHEE_PORT=8080`).
 
 
 

--- a/index.js
+++ b/index.js
@@ -327,7 +327,9 @@ app.all('/health', (req, res) => {
 
 // Start listening
 const port = process.env.PORT || process.env.CRUSHEE_PORT || 1603
-app.listen(port, (e) => {
-    console.log(`Starting server v${serverVersion} on port ${port}`)
+// On macOS, $HOST is already taken by default.
+const host = process.env.CRUSHEE_HOST || '127.0.0.1';
+app.listen(port, host, (e) => {
+    console.log(`Starting server v${serverVersion} on ${host}:${port}`)
 })
 


### PR DESCRIPTION
Listening on `0.0.0.0` by default probably isn't a best practice at this
stage: the "usual" use case is currently `localhost` centric. So
instead, we'll default to `127.0.0.1` and if the user would like to
listen to any other interface, including globally, they can export
`CRUSHEE_HOST` with the appropriate interface like they currently do
with `CRUSHEE_PORT` or `PORT`.

Take note that we can only use `CRUSHEE_HOST` here instead of also
looking for `HOST`: on macOS 10.14.3, `HOST` is set to the computer's
local name by default, which will cause issues if the same `HOST`
value isn't also present in `/etc/hosts`.